### PR TITLE
Shadow Priest Update

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -1972,6 +1972,78 @@ all:RegisterAuras({
         end
     },
 
+    stamina = {
+        id = 21562, -- Use Fortitude as primary ID
+        duration = 3600,
+        max_stack = 1,
+        generate = function( t )
+            -- Commanding Shout
+            local name, icon, count, debuffType, duration, expirationTime, caster = FindUnitBuffByID("player", 469)
+            if name then
+                t.name = name
+                t.count = 1
+                t.expires = expirationTime or 0
+                t.applied = (expirationTime and duration) and (expirationTime - duration) or 0
+                t.caster = caster
+                t.up = true
+                t.down = false
+                t.remains = expirationTime and (expirationTime - GetTime()) or 0
+                return
+            end
+
+            -- Power Word: Fortitude
+            name, icon, count, debuffType, duration, expirationTime, caster = FindUnitBuffByID("player", 21562)
+            if name then
+                t.name = name
+                t.count = 1
+                t.expires = expirationTime or 0
+                t.applied = (expirationTime and duration) and (expirationTime - duration) or 0
+                t.caster = caster
+                t.up = true
+                t.down = false
+                t.remains = expirationTime and (expirationTime - GetTime()) or 0
+                return
+            end
+
+            -- Dark Intent
+            name, icon, count, debuffType, duration, expirationTime, caster = FindUnitBuffByID("player", 109773)
+            if name then
+                t.name = name
+                t.count = 1
+                t.expires = expirationTime or 0
+                t.applied = (expirationTime and duration) and (expirationTime - duration) or 0
+                t.caster = caster
+                t.up = true
+                t.down = false
+                t.remains = expirationTime and (expirationTime - GetTime()) or 0
+                return
+            end
+
+            -- Qiraji Fortitude (Pet)
+            name, icon, count, debuffType, duration, expirationTime, caster = FindUnitBuffByID("player", 90364)
+            if name then
+                t.name = name
+                t.count = 1
+                t.expires = expirationTime or 0
+                t.applied = (expirationTime and duration) and (expirationTime - duration) or 0
+                t.caster = caster
+                t.up = true
+                t.down = false
+                t.remains = expirationTime and (expirationTime - GetTime()) or 0
+                return
+            end
+
+            -- No stamina buff found
+            t.count = 0
+            t.expires = 0
+            t.applied = 0
+            t.caster = "nobody"
+            t.up = false
+            t.down = true
+            t.remains = 0
+        end
+    },
+
     out_of_range = {
         generate = function ( oor )
             oor.rangeSpell = rawget( oor, "rangeSpell" ) or settings.spec.rangeChecker or class.specs[ state.spec.id ].ranges[ 1 ]

--- a/Constants.lua
+++ b/Constants.lua
@@ -175,6 +175,7 @@ local MoPPowerTypes = {
     blood_runes     = 20,
     frost_runes     = 21,
     unholy_runes    = 22,
+    shadow_orbs     = 28,
 }
 
 local ResourceInfo = {
@@ -203,6 +204,7 @@ local ResourceInfo = {
     blood_runes     = (Enum and Enum.PowerType and Enum.PowerType.RuneBlood) or MoPPowerTypes.RuneBlood,
     frost_runes     = (Enum and Enum.PowerType and Enum.PowerType.RuneFrost) or MoPPowerTypes.RuneFrost,
     unholy_runes    = (Enum and Enum.PowerType and Enum.PowerType.RuneUnholy) or MoPPowerTypes.RuneUnholy,
+    shadow_orbs     = (Enum and Enum.PowerType and Enum.PowerType.ShadowOrbs) or MoPPowerTypes.ShadowOrbs,
 }
 
 local ResourceByID = {}

--- a/MistsOfPandaria/Priorities/PriestShadow.simc
+++ b/MistsOfPandaria/Priorities/PriestShadow.simc
@@ -1,59 +1,42 @@
 # Priest: Shadow
-actions.precombat+=/inner_fire
-actions.precombat+=/shadowform,if=!buff.shadowform.up
-actions.precombat+=/power_word_fortitude,if=!buff.power_word_fortitude.up
-actions.precombat+=/vampiric_embrace,if=!buff.vampiric_embrace.up
-actions.precombat+=/variable,name=trinket_sync_slot,value=1,if=trinket.1.has_cooldown&(!trinket.2.has_cooldown|trinket.1.cooldown.duration>=trinket.2.cooldown.duration)
-actions.precombat+=/variable,name=trinket_sync_slot,value=2,if=trinket.2.has_cooldown&(!trinket.1.has_cooldown|trinket.2.cooldown.duration>trinket.1.cooldown.duration)
+# SimCraft 548-8
 
-# Main rotation - calls specialized action lists
-actions+=/silence
-actions+=/shadowform,if=!buff.shadowform.up
-actions+=/dispersion,if=mana.pct<5
-actions+=/call_action_list,name=cooldowns
-actions+=/call_action_list,name=aoe,if=active_enemies>=4
-actions+=/call_action_list,name=single_target
+actions.precombat+=/power_word_fortitude,if=buff.power_word_fortitude.down
+actions.precombat+=/inner_fire,if=buff.inner_fire.down
+actions.precombat+=/shadowform,if=buff.shadowform.down
+actions.precombat+=/potion
 
-# Cooldowns
-actions.cooldowns+=/potion,if=buff.bloodlust.react|target.time_to_die<=40
-actions.cooldowns+=/power_infusion,if=talent.power_infusion.enabled&buff.bloodlust.up
-actions.cooldowns+=/power_infusion,if=talent.power_infusion.enabled&target.time_to_die<=20
-actions.cooldowns+=/berserking,if=buff.bloodlust.up|buff.power_infusion.up|target.time_to_die<=20
-actions.cooldowns+=/blood_fury,if=buff.bloodlust.up|buff.power_infusion.up|target.time_to_die<=20
-actions.cooldowns+=/arcane_torrent,if=mana.pct<95
-actions.cooldowns+=/shadowfiend,if=talent.mindbender.enabled
-actions.cooldowns+=/shadowfiend,if=!talent.mindbender.enabled&mana.pct<80
-actions.cooldowns+=/mindbender,if=talent.mindbender.enabled
-actions.cooldowns+=/use_item,slot=trinket1,if=variable.trinket_sync_slot=1&(buff.bloodlust.up|buff.power_infusion.up|target.time_to_die<=20)
-actions.cooldowns+=/use_item,slot=trinket2,if=variable.trinket_sync_slot=2&(buff.bloodlust.up|buff.power_infusion.up|target.time_to_die<=20)
 
-# AoE rotation
-actions.aoe+=/mind_sear,if=active_enemies>=4
-actions.aoe+=/vampiric_touch,cycle_targets=1,max_cycle_targets=5,if=(!ticking|remains<cast_time)&target.time_to_die>10&active_enemies<10
-actions.aoe+=/shadow_word_pain,cycle_targets=1,max_cycle_targets=10,if=!ticking&target.time_to_die>10&active_enemies<10
-actions.aoe+=/mind_blast,if=shadow_orb<3&active_enemies<8
-actions.aoe+=/shadow_word_death,if=target.health.pct<20
-actions.aoe+=/cascade,if=talent.cascade.enabled
-actions.aoe+=/divine_star,if=talent.divine_star.enabled
-actions.aoe+=/halo,if=talent.halo.enabled
-actions.aoe+=/mind_flay,interrupt_if=ticks>=2&shadow_orb=3
-actions.aoe+=/devouring_plague,if=shadow_orb=3&ticks_remain<2
-actions.aoe+=/mind_flay,interrupt_if=shadow_orb=3&ticks_remain<2
-
-# Single target rotation
-actions.single_target+=/variable,name=dots_up,value=dot.shadow_word_pain.ticking&dot.vampiric_touch.ticking
-actions.single_target+=/variable,name=orbs_to_spend,value=shadow_orb=3|(buff.shadow_word_insanity.up&shadow_orb>=1)
-actions.single_target+=/devouring_plague,if=variable.orbs_to_spend&variable.dots_up
-actions.single_target+=/shadow_word_death,if=target.health.pct<20
-actions.single_target+=/mind_blast,if=shadow_orb<3&variable.dots_up
-actions.single_target+=/shadow_word_pain,if=!ticking&target.time_to_die>8
-actions.single_target+=/vampiric_touch,if=(!ticking|remains<cast_time+action.mind_blast.cast_time)&target.time_to_die>8
-actions.single_target+=/cascade,if=talent.cascade.enabled
-actions.single_target+=/divine_star,if=talent.divine_star.enabled
-actions.single_target+=/halo,if=talent.halo.enabled
-actions.single_target+=/mind_spike,if=talent.from_darkness_comes_light.enabled&buff.surge_of_darkness.react
-actions.single_target+=/shadow_word_insanity,if=talent.shadow_word_insanity.enabled&buff.shadow_word_insanity.up&shadow_orb>=1
-actions.single_target+=/mind_flay,interrupt_if=ticks>=2&shadow_orb=3
-actions.single_target+=/shadow_word_death,if=cooldown_react
-actions.single_target+=/mind_spike,if=target.time_to_die<=10&target.time_to_die>=3
-actions.single_target+=/mind_flay
+actions+=/shadowform,if=buff.shadowform.down
+actions+=/potion,if=buff.bloodlust.react|target.time_to_die<=40
+actions+=/shadowfiend
+actions+=/power_infusion,if=talent.power_infusion.enabled
+actions+=/blood_fury
+actions+=/berserking
+actions+=/arcane_torrent
+actions+=/shadow_word_death,if=buff.shadow_word_death_reset_cooldown.up&active_enemies<=5
+actions+=/devouring_plague,if=shadow_orb.count=3&(cooldown.mind_blast.remains<1.5|target.health.pct<20&cooldown.shadow_word_death.remains<1.5)
+actions+=/mind_blast,if=active_enemies<=5
+actions+=/shadow_word_death,if=buff.shadow_word_death_reset_cooldown.down&active_enemies<=5
+actions+=/mind_flay,if=debuff.devouring_plague.ticks_remain<=1&debuff.devouring_plague.down&talent.solace_and_insanity.enabled,chain=1
+actions+=/shadow_word_pain,cycle_targets=1,max_cycle_targets=5,if=buff.shadow_word_pain.down
+actions+=/vampiric_touch,cycle_targets=1,max_cycle_targets=5,if=debuff.vampiric_touch.remains<cast_time
+actions+=/shadow_word_pain,cycle_targets=1,max_cycle_targets=5,if=ticks_remain<=1
+actions+=/vampiric_touch,cycle_targets=1,max_cycle_targets=5,if=debuff.vampiric_touch.remains<cast_time+tick_time
+actions+=/vampiric_embrace,if=shadow_orb.count=3&health.pct<=40
+actions+=/devouring_plague,if=shadow_orb.count=3&ticks_remain<=1
+actions+=/mind_spike,if=active_enemies<=5&buff.surge_of_darkness.react=2
+actions+=/halo,if=talent.halo.enabled&target.distance<=30&target.distance>=17
+actions+=/cascade,if=talent.cascade.enabled&(active_enemies>1|(target.distance>=25&stat.mastery_rating<15000)|target.distance>=28)&target.distance<=40&target.distance>=11
+actions+=/divine_star,if=talent.divine_star.enabled&(active_enemies>1|stat.mastery_rating<3500)&target.distance<=24
+actions+=/wait,sec=cooldown.shadow_word_death.remains,if=target.health.pct<20&cooldown.shadow_word_death.remains<0.5&active_enemies<=1
+actions+=/wait,sec=cooldown.mind_blast.remains,if=cooldown.mind_blast.remains<0.5&active_enemies<=1
+actions+=/mind_spike,if=buff.surge_of_darkness.react&active_enemies<=5
+actions+=/mind_sear,chain=1,interrupt=1,if=active_enemies>=3
+actions+=/mind_flay,chain=1,interrupt=1
+actions+=/shadow_word_death,moving=1
+actions+=/mind_blast,moving=1,if=buff.divine_insight.react
+actions+=/divine_star,moving=1,if=talent.divine_star.enabled&target.distance<=28
+actions+=/cascade,moving=1,if=talent.cascade.enabled&target.distance<=40
+actions+=/shadow_word_pain,moving=1
+actions+=/dispersion


### PR DESCRIPTION
Changes made:
- Added Shadow Orbs as a resource
- Added global `stamina` buff tracker alias
- Updated and optimized the APL with last SimCraft data from original MoP
- Commented out several sections of code involving resource tracking that were causing crashes. It wasn't worth the headache fixing them currently, as resource tracking isn't super impactful for Shadow
- Updated the Shadow Orbs tracking to use the correct resource values
- Removed Shadow Orbs tracking from critical hits on dots, as these do not generate Shadow Orbs
- Added Shadow Orbs tracking for Shadow Word: Death, which generates an orb on non-reset uses
- Added a value to track if Shadow Word: Death is on its reset cooldown
- Removed several mentions of Dark Archangel, which no longer exists
- Corrected a talent referencing Archangel to instead link to Solace and Insanity
- Corrected Divine Insight referencing the incorrect ID for Shadow
- Fixed an issue where dots' remaining time wouldn't properly update when changing targets
- Added several missing abilities